### PR TITLE
feature: mute/restore BGM (#5)

### DIFF
--- a/FantasyPlayer/Config/PlayerSettings.cs
+++ b/FantasyPlayer/Config/PlayerSettings.cs
@@ -126,6 +126,12 @@ namespace FantasyPlayer.Config
             set => SetField(ref chatType, value);
         }
 
+        private bool muteBgmOnPlayback = true;
+        public bool MuteBgmOnPlayback
+        {
+            get => muteBgmOnPlayback;
+            set => SetField(ref muteBgmOnPlayback, value);
+        }
         public PlayerSettings()
         {
             

--- a/FantasyPlayer/Interface/Window/SettingsWindow.cs
+++ b/FantasyPlayer/Interface/Window/SettingsWindow.cs
@@ -163,6 +163,14 @@ namespace FantasyPlayer.Interface.Window
 
                 ImGui.Separator();
 
+                var muteBgmOnPlayback = _configuration.PlayerSettings.MuteBgmOnPlayback;
+                if (ImGui.Checkbox("Mute BGM when playing", ref muteBgmOnPlayback))
+                {
+                    _configuration.PlayerSettings.MuteBgmOnPlayback = muteBgmOnPlayback;
+                }
+
+                ImGui.Separator();
+
                 if (!_configuration.SpotifySettings.LimitedAccess)
                 {
                     var compactPlayer = _configuration.PlayerSettings.CompactPlayer;

--- a/FantasyPlayer/Manager/BgmService.cs
+++ b/FantasyPlayer/Manager/BgmService.cs
@@ -59,10 +59,12 @@
                 {
                     gameConfig.TryGet(SystemConfigOption.SoundBgm, out _savedBgmVolume);
                     gameConfig.Set(SystemConfigOption.SoundBgm, 0u);
+                    _isMuted = true;
                 }
                 else
                 {
                     gameConfig.Set(SystemConfigOption.SoundBgm, _savedBgmVolume);
+                    _isMuted = false;
                 }
                 _isMuted = isPlaying;
             });

--- a/FantasyPlayer/Manager/BgmService.cs
+++ b/FantasyPlayer/Manager/BgmService.cs
@@ -1,0 +1,71 @@
+﻿namespace FantasyPlayer.Manager
+{
+    using Config;
+    using Dalamud.Game.Config;
+    using Dalamud.Plugin.Services;
+    using Microsoft.Extensions.Hosting;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class BgmService : IHostedService
+    {
+        private readonly IGameConfig gameConfig;
+        private readonly Configuration config;
+        private readonly IFramework framework;
+        private readonly PlayerManager playerManager;
+        private readonly IPluginLog log;
+
+        private bool _isMuted = false;
+        private uint _savedBgmVolume = 100;
+
+        public BgmService(IGameConfig gameConfig, Configuration config, IFramework framework, PlayerManager playerManager, IPluginLog log)
+        {
+            this.gameConfig = gameConfig;
+            this.config = config;
+            this.framework = framework;
+            this.playerManager = playerManager;
+            this.log = log;
+        }
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            foreach (var provider in playerManager.PlayerProviders)
+                provider.PlaybackStateChanged += OnPlaybackStateChanged;
+            return Task.CompletedTask;
+        }
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            foreach (var provider in playerManager.PlayerProviders)
+                provider.PlaybackStateChanged -= OnPlaybackStateChanged;
+            try
+            {
+                if (_isMuted)
+                {
+                    gameConfig.Set(SystemConfigOption.SoundBgm, _savedBgmVolume);
+                }
+            }
+            catch 
+            {
+                log.Error("Failed to restore BGM volume on shutdown.");
+            }
+            return Task.CompletedTask;
+        }
+        private void OnPlaybackStateChanged(bool isPlaying)
+        {
+            if (!config.PlayerSettings.MuteBgmOnPlayback)
+                return;
+            framework.RunOnFrameworkThread(() =>
+            {
+                if (isPlaying)
+                {
+                    gameConfig.TryGet(SystemConfigOption.SoundBgm, out _savedBgmVolume);
+                    gameConfig.Set(SystemConfigOption.SoundBgm, 0u);
+                }
+                else
+                {
+                    gameConfig.Set(SystemConfigOption.SoundBgm, _savedBgmVolume);
+                }
+                _isMuted = isPlaying;
+            });
+        }
+    }
+}

--- a/FantasyPlayer/Manager/PlayerManager.cs
+++ b/FantasyPlayer/Manager/PlayerManager.cs
@@ -25,10 +25,6 @@ namespace FantasyPlayer.Manager
         private readonly IPluginLog pluginLog;
         private readonly Configuration configuration;
         private readonly IFramework framework;
-        private readonly IGameConfig gameConfig;
-
-        private bool _wasPlaying = false;
-        private uint _savedBgmVolume = 100;
         public IPlayerProvider? CurrentPlayerProvider;
 
         public bool ProvidersLoading
@@ -42,13 +38,12 @@ namespace FantasyPlayer.Manager
         public List<IPlayerProvider> PlayerProviders { get; }
 
         public PlayerManager(IPluginLog pluginLog, Configuration configuration, IEnumerable<IPlayerProvider> playerProviders, 
-            IFramework framework, IGameConfig gameConfig)
+            IFramework framework)
         {
             this.pluginLog = pluginLog;
             this.configuration = configuration;
             this.PlayerProviders = playerProviders.ToList();
             this.framework = framework;
-            this.gameConfig = gameConfig;
             SetupDefaultProvider();
         }
 
@@ -71,28 +66,6 @@ namespace FantasyPlayer.Manager
         {
             foreach (var playerProvider in PlayerProviders)
                 playerProvider.Update();
-            if (!configuration.PlayerSettings.MuteBgmOnPlayback)
-            {
-                if (_wasPlaying)
-                {
-                    gameConfig.Set(SystemConfigOption.SoundBgm, _savedBgmVolume);
-                    _wasPlaying = false;
-                }
-                return;
-            }
-
-            var isPlaying = CurrentPlayerProvider != null && CurrentPlayerProvider.PlayerState.IsPlaying;
-
-            if (isPlaying && !_wasPlaying)
-            {
-                gameConfig.TryGet(SystemConfigOption.SoundBgm, out _savedBgmVolume);
-                gameConfig.Set(SystemConfigOption.SoundBgm, 0u);
-            }
-            else if (!isPlaying && _wasPlaying)
-            {
-                gameConfig.Set(SystemConfigOption.SoundBgm, _savedBgmVolume);
-            }
-            _wasPlaying = isPlaying;
         }
 
         public override async Task StartAsync(CancellationToken cancellationToken)
@@ -105,8 +78,6 @@ namespace FantasyPlayer.Manager
         {
             this.framework.Update -= Update;
 
-            if (_wasPlaying)
-                gameConfig.Set(SystemConfigOption.SoundBgm, _savedBgmVolume);
             await base.StopAsync(cancellationToken);
         }
 

--- a/FantasyPlayer/Manager/PlayerManager.cs
+++ b/FantasyPlayer/Manager/PlayerManager.cs
@@ -15,6 +15,7 @@ namespace FantasyPlayer.Manager
 {
     using System.Threading;
     using Config;
+    using Dalamud.Game.Config;
     using Dalamud.Plugin.Services;
     using Microsoft.Extensions.Hosting;
 
@@ -23,7 +24,10 @@ namespace FantasyPlayer.Manager
         private readonly IPluginLog pluginLog;
         private readonly Configuration configuration;
         private readonly IFramework framework;
+        private readonly IGameConfig gameConfig;
 
+        private bool _wasPlaying = false;
+        private uint _savedBgmVolume = 100;
         public IPlayerProvider? CurrentPlayerProvider;
 
         public bool ProvidersLoading
@@ -36,12 +40,14 @@ namespace FantasyPlayer.Manager
 
         public List<IPlayerProvider> PlayerProviders { get; }
 
-        public PlayerManager(IPluginLog pluginLog, Configuration configuration, IEnumerable<IPlayerProvider> playerProviders, IFramework framework)
+        public PlayerManager(IPluginLog pluginLog, Configuration configuration, IEnumerable<IPlayerProvider> playerProviders, 
+            IFramework framework, IGameConfig gameConfig, ICommandManager command)
         {
             this.pluginLog = pluginLog;
             this.configuration = configuration;
             this.PlayerProviders = playerProviders.ToList();
             this.framework = framework;
+            this.gameConfig = gameConfig;
             SetupDefaultProvider();
         }
 
@@ -64,6 +70,17 @@ namespace FantasyPlayer.Manager
         {
             foreach (var playerProvider in PlayerProviders)
                 playerProvider.Update();
+            var isPlaying = CurrentPlayerProvider != null && CurrentPlayerProvider.PlayerState.IsPlaying;
+
+            if (isPlaying && !_wasPlaying)
+            {
+                gameConfig.TryGet(SystemConfigOption.SoundBgm, out _savedBgmVolume);
+                gameConfig.Set(SystemConfigOption.SoundBgm, 0u);
+            }
+            else if (!isPlaying && _wasPlaying)
+            {
+                gameConfig.Set(SystemConfigOption.SoundBgm, _savedBgmVolume);
+            }
         }
 
         public override async Task StartAsync(CancellationToken cancellationToken)

--- a/FantasyPlayer/Manager/PlayerManager.cs
+++ b/FantasyPlayer/Manager/PlayerManager.cs
@@ -42,7 +42,7 @@ namespace FantasyPlayer.Manager
         public List<IPlayerProvider> PlayerProviders { get; }
 
         public PlayerManager(IPluginLog pluginLog, Configuration configuration, IEnumerable<IPlayerProvider> playerProviders, 
-            IFramework framework, IGameConfig gameConfig, ICommandManager command)
+            IFramework framework, IGameConfig gameConfig)
         {
             this.pluginLog = pluginLog;
             this.configuration = configuration;
@@ -71,6 +71,16 @@ namespace FantasyPlayer.Manager
         {
             foreach (var playerProvider in PlayerProviders)
                 playerProvider.Update();
+            if (!configuration.PlayerSettings.MuteBgmOnPlayback)
+            {
+                if (_wasPlaying)
+                {
+                    gameConfig.Set(SystemConfigOption.SoundBgm, _savedBgmVolume);
+                    _wasPlaying = false;
+                }
+                return;
+            }
+
             var isPlaying = CurrentPlayerProvider != null && CurrentPlayerProvider.PlayerState.IsPlaying;
 
             if (isPlaying && !_wasPlaying)
@@ -95,7 +105,7 @@ namespace FantasyPlayer.Manager
         {
             this.framework.Update -= Update;
 
-            if(_wasPlaying)
+            if (_wasPlaying)
                 gameConfig.Set(SystemConfigOption.SoundBgm, _savedBgmVolume);
             await base.StopAsync(cancellationToken);
         }

--- a/FantasyPlayer/Manager/PlayerManager.cs
+++ b/FantasyPlayer/Manager/PlayerManager.cs
@@ -15,9 +15,10 @@ namespace FantasyPlayer.Manager
 {
     using System.Threading;
     using Config;
-    using Dalamud.Game.Config;
     using Dalamud.Plugin.Services;
     using Microsoft.Extensions.Hosting;
+    using Dalamud.Game.Config;
+
 
     public class PlayerManager : BackgroundService
     {
@@ -92,6 +93,9 @@ namespace FantasyPlayer.Manager
         public override async Task StopAsync(CancellationToken cancellationToken)
         {
             this.framework.Update -= Update;
+
+            if(_wasPlaying)
+                gameConfig.Set(SystemConfigOption.SoundBgm, _savedBgmVolume);
             await base.StopAsync(cancellationToken);
         }
 

--- a/FantasyPlayer/Manager/PlayerManager.cs
+++ b/FantasyPlayer/Manager/PlayerManager.cs
@@ -82,6 +82,7 @@ namespace FantasyPlayer.Manager
             {
                 gameConfig.Set(SystemConfigOption.SoundBgm, _savedBgmVolume);
             }
+            _wasPlaying = isPlaying;
         }
 
         public override async Task StartAsync(CancellationToken cancellationToken)

--- a/FantasyPlayer/Plugin.cs
+++ b/FantasyPlayer/Plugin.cs
@@ -56,6 +56,7 @@ namespace FantasyPlayer
             containerBuilder.RegisterType<Font>().As<IFont>().SingleInstance();
             containerBuilder.RegisterType<SpotifyProvider>().As<IPlayerProvider>().SingleInstance();
             containerBuilder.RegisterType<IpcService>().SingleInstance();
+            containerBuilder.RegisterType<BgmService>().SingleInstance();
         }
 
         public override void ConfigureServices(IServiceCollection serviceCollection)
@@ -67,6 +68,7 @@ namespace FantasyPlayer
             serviceCollection.AddHostedService(p => p.GetRequiredService<CommandsService>());
             serviceCollection.AddHostedService(p => p.GetRequiredService<MediatorService>());
             serviceCollection.AddHostedService(p => p.GetRequiredService<IpcService>());
+            serviceCollection.AddHostedService(p => p.GetRequiredService<BgmService>());
         }
     }
 }

--- a/FantasyPlayer/Provider/Common/IPlayerProvider.cs
+++ b/FantasyPlayer/Provider/Common/IPlayerProvider.cs
@@ -24,5 +24,7 @@ namespace FantasyPlayer.Provider.Common
         public void SetSkip(bool forward);
         public void SetShuffle(bool value);
         public void SetVolume(int volume);
+
+        event Action<bool>? PlaybackStateChanged;
     }
 }

--- a/FantasyPlayer/Provider/SpotifyProvider.cs
+++ b/FantasyPlayer/Provider/SpotifyProvider.cs
@@ -12,6 +12,7 @@ namespace FantasyPlayer.Provider
     using Config;
     using Dalamud.Plugin.Services;
     using Manager;
+    using System;
 
     public class SpotifyProvider : IPlayerProvider
     {
@@ -98,8 +99,10 @@ namespace FantasyPlayer.Provider
                     Name = playbackItem.Album.Name
                 }
             };
-
+            bool wasPlaying = PlayerState.IsPlaying;
             PlayerState = playerStateStruct;
+            if(wasPlaying != PlayerState.IsPlaying)
+                PlaybackStateChanged?.Invoke(PlayerState.IsPlaying);
         }
 
         private void OnLoggedIn(PrivateUser privateUser, PKCETokenResponse tokenResponse)
@@ -214,5 +217,6 @@ namespace FantasyPlayer.Provider
         {
             return Task.CompletedTask;
         }
+        public event Action<bool>? PlaybackStateChanged; 
     }
 }


### PR DESCRIPTION
Added BGM control for when music is playing 

on music start: 
* stores current BGM value 
* sets BGM to 0 

on music stop: 
* sets BGM to stored value

on plugin unload:
* set BGM to stored value